### PR TITLE
[05] corrigindo href do logo mais uma vez

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -10,7 +10,7 @@
 
 <body>
     <nav id="navArea">
-        <a href="/dashboard" class="logo"><img class="logo" src="../images/LogoAppuser.png" alt="Logo APPUSER"></a>
+        <a href="index.html" class="logo"><img class="logo" src="../images/LogoAppuser.png" alt="Logo APPUSER"></a>
         <ul>
           <li><a class="menu" href="address-form.html">Cadastrar endereço</a></li>
           <li><a class="menu" href="address-list.html">Listar endereços</a></li>


### PR DESCRIPTION
Colocando o href do logo para /dashboard, o navegador não reconhece o index.html dessa pasta. Foi necessário colocar direto href= "index.html"